### PR TITLE
Add sideEffects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/esm/index.js",
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Add sideEffects to package.json, to help bundler cut unused code. Good with named imports.